### PR TITLE
fix: screen scales correctly

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,7 +18,7 @@ config/icon="res://icon.svg"
 
 window/size/viewport_width=320
 window/size/viewport_height=180
-window/stretch/mode="canvas_items"
+window/stretch/mode="viewport"
 
 [input]
 


### PR DESCRIPTION
The screen now scales properly by keeping the resolution instead of making it higher